### PR TITLE
Updated version of pd-for android to final 1.0.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,5 +48,5 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'org.puredata.android:pd-core:1.0.0-rc3'
+    compile 'org.puredata.android:pd-core:1.0.0'
 }


### PR DESCRIPTION
Besides being an official release (and no longer a release candidate) this version contains a fix to a bug in the rc3 version that PdDroidParty currently depends on.