### PR TITLE
more buildtool upgrades

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="cx.mccormick.pddroidparty">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <supports-screens android:largeScreens="true" android:normalScreens="true" android:smallScreens="true" android:anyDensity="true" />
   <application android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@android:style/Theme.NoTitleBar">
-    <activity android:name=".PatchSelector" android:label="@string/app_name" android:configChanges="orientation" android:launchMode="singleTask">
+    <activity android:name=".PatchSelector" android:label="@string/app_name" android:configChanges="orientation" 
+            android:launchMode="singleTask" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
@@ -40,7 +40,6 @@
     <activity android:name=".LoadDialog" android:theme="@android:style/Theme.Dialog" android:configChanges="orientation" android:label="Load"></activity>
     <service android:name="org.puredata.android.service.PdService" />
   </application>
-  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,31 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:8.1.1'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "29.0.2"
+    namespace = 'cx.mccormick.pddroidparty'
+    compileSdkVersion 34
+    ndkVersion = '24.0.8215888'
 
     defaultConfig {
         applicationId "cx.mccormick.pddroidparty"
         minSdkVersion 17
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode = project.hasProperty('versionCode') ? project.getProperty('versionCode').toInteger() : 1
         versionName = project.hasProperty('versionName') ? project.getProperty('versionName') : ""
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip


### PR DESCRIPTION
- set target sdk to 34 (required to create new apps)
- use ndk 24.0.8215888
- use gradle plugin 8.1.1
- use gradle wrapper 8.10
- fix manifest and gradle.build accordingly
- add gradle.properties file for androidx

Sidenote: Java17 is now required.
