### PR TITLE
improve drawing of Bang, Toggle and Slider widgets

### DIFF
--- a/src/cx/mccormick/pddroidparty/Bang.java
+++ b/src/cx/mccormick/pddroidparty/Bang.java
@@ -54,15 +54,12 @@ public class Bang extends Widget {
 			canvas.drawRect(dRect, paint);
 
 			paint.setColor(Color.BLACK);
+			paint.setStyle(Paint.Style.STROKE);
 			paint.setStrokeWidth(1);
-			canvas.drawLine(dRect.left /*+ 1*/, dRect.top, dRect.right, dRect.top, paint);
-			canvas.drawLine(dRect.left + 0, dRect.bottom, dRect.right, dRect.bottom, paint);
-			canvas.drawLine(dRect.left, dRect.top + 0, dRect.left, dRect.bottom, paint);
-			canvas.drawLine(dRect.right, dRect.top + 0, dRect.right, dRect.bottom, paint);
+			canvas.drawRect(dRect, paint);
 			if (bang && on.draw(canvas)) {
 				if((SystemClock.uptimeMillis() - bangtime) > hold) bang = false;
-				//paint.setStyle(Paint.Style.FILL);
-
+				paint.setStyle(Paint.Style.FILL);
 				parent.threadSafeInvalidate();
 				canvas.drawCircle(dRect.centerX(), dRect.centerY(), Math.min(dRect.width(), dRect.height()) / 2, paint);
 				paint.setColor(fgcolor);

--- a/src/cx/mccormick/pddroidparty/Slider.java
+++ b/src/cx/mccormick/pddroidparty/Slider.java
@@ -82,18 +82,19 @@ public class Slider extends Widget {
 			paint.setStyle(Paint.Style.FILL);
 			canvas.drawRect(dRect, paint);
 
+			paint.setStyle(Paint.Style.STROKE);
 			paint.setColor(Color.BLACK);
 			paint.setStrokeWidth(1);
-			canvas.drawLine(dRect.left /*+ 1*/, dRect.top, dRect.right, dRect.top, paint);
-			canvas.drawLine(dRect.left /*+ 1*/, dRect.bottom, dRect.right, dRect.bottom, paint);
-			canvas.drawLine(dRect.left, dRect.top /*+ 1*/, dRect.left, dRect.bottom, paint);
-			canvas.drawLine(dRect.right, dRect.top /*+ 1*/, dRect.right, dRect.bottom, paint);
+			canvas.drawRect(dRect, paint);
 			paint.setColor(fgcolor);
-			paint.setStrokeWidth(3);
+			float handle_width = 3;
+			paint.setStrokeWidth(handle_width);
 			if (orientation_horizontal) {
-				canvas.drawLine(Math.round(dRect.left + ((val - min) / (max - min)) * dRect.width()), Math.round(dRect.top /*+ 2*/), Math.round(dRect.left + ((val - min) / (max - min)) * dRect.width()), Math.round(dRect.bottom /*- 2*/), paint);
+				float x = dRect.left + ((val - min) / (max - min)) * (dRect.width() - handle_width) + handle_width / 2;
+				canvas.drawLine(x, dRect.top, x, dRect.bottom, paint);
 			} else {
-				canvas.drawLine(Math.round(dRect.left /*+ 2*/), Math.round(dRect.bottom - ((val - min) / (max - min)) * dRect.height()), Math.round(dRect.right /*- 2*/), Math.round(dRect.bottom - ((val - min) / (max - min)) * dRect.height()), paint);
+				float y = dRect.bottom - ((val - min) / (max - min)) * (dRect.height() - handle_width) - handle_width / 2;
+				canvas.drawLine(dRect.left, y, dRect.right, y, paint);
 			}
 
 		} else if (!slider.none()) {

--- a/src/cx/mccormick/pddroidparty/Toggle.java
+++ b/src/cx/mccormick/pddroidparty/Toggle.java
@@ -47,10 +47,8 @@ public class Toggle extends Widget {
 
 			paint.setColor(Color.BLACK);
 			paint.setStrokeWidth(1);
-			canvas.drawLine(dRect.left /*+ 1*/, dRect.top, dRect.right, dRect.top, paint);
-			canvas.drawLine(dRect.left /*+ 1*/, dRect.bottom, dRect.right, dRect.bottom, paint);
-			canvas.drawLine(dRect.left, dRect.top /*+ 1*/, dRect.left, dRect.bottom, paint);
-			canvas.drawLine(dRect.right, dRect.top /*+ 1*/, dRect.right, dRect.bottom, paint);
+			paint.setStyle(Paint.Style.STROKE);
+			canvas.drawRect(dRect, paint);
 		}
 
 		if (val != 0) {


### PR DESCRIPTION
- use drawRect instead of lines for nicer corners
- Slider: don't round coordinates
- Slider: compensate handle position according to its width

before:
![Screenshot_2025-06-28-19-29-56-057](https://github.com/user-attachments/assets/9b03c56f-f093-47eb-b023-a7b62e23e49a)

now:
![Screenshot_2025-06-28-19-28-01-428](https://github.com/user-attachments/assets/a804508f-2670-43bd-ad33-e4d0df825719)
