### PR TITLE
fix dollarzero not being replaced in receivenames

### DIFF
--- a/src/cx/mccormick/pddroidparty/Display.java
+++ b/src/cx/mccormick/pddroidparty/Display.java
@@ -29,7 +29,7 @@ public class Display extends Widget {
 		paint.setTextSize(fontsize);
 		paint.setTextAlign(Paint.Align.CENTER);
 
-		receivename = atomline[7];
+		receivename = app.app.replaceDollarZero(atomline[7]);
 
 		// graphics setup
 		dRect = new RectF(Math.round(x), Math.round(y), Math.round(x + w),

--- a/src/cx/mccormick/pddroidparty/Numberbox.java
+++ b/src/cx/mccormick/pddroidparty/Numberbox.java
@@ -51,7 +51,7 @@ public class Numberbox extends Widget {
 		min = Float.parseFloat(atomline[5]);
 		max = Float.parseFloat(atomline[6]);
 		sendname = app.app.replaceDollarZero(atomline[10]);
-		receivename = atomline[9];
+		receivename = app.app.replaceDollarZero(atomline[9]);
 		label = setLabel(atomline[8]);
 		labelpos[0] = x;
 		labelpos[1] = y;

--- a/src/cx/mccormick/pddroidparty/Numberbox2.java
+++ b/src/cx/mccormick/pddroidparty/Numberbox2.java
@@ -47,7 +47,7 @@ public class Numberbox2 extends Numberbox {
 		max = Float.parseFloat(atomline[8]);
 		init = Integer.parseInt(atomline[10]);
 		sendname = app.app.replaceDollarZero(atomline[11]);
-		receivename = atomline[12];
+		receivename = app.app.replaceDollarZero(atomline[12]);
 		label = setLabel(atomline[13]);
 		labelpos[0] = Float.parseFloat(atomline[14]) ;
 		labelpos[1] = Float.parseFloat(atomline[15]) ;

--- a/src/cx/mccormick/pddroidparty/Numberboxfixed.java
+++ b/src/cx/mccormick/pddroidparty/Numberboxfixed.java
@@ -41,7 +41,7 @@ public class Numberboxfixed extends Numberbox {
 		max = Float.parseFloat(atomline[10]);
 		init = 1;
 		sendname = app.app.replaceDollarZero(atomline[8]);
-		receivename = atomline[7];
+		receivename = app.app.replaceDollarZero(atomline[7]);
 
 		// set the value to the init value if possible
 		setval(Float.parseFloat(atomline[11]), 0);

--- a/src/cx/mccormick/pddroidparty/Taplist.java
+++ b/src/cx/mccormick/pddroidparty/Taplist.java
@@ -41,7 +41,7 @@ public class Taplist extends Widget {
 		paint.setTextAlign(Paint.Align.CENTER);
 
 		sendname = app.app.replaceDollarZero(atomline[8]);
-		receivename = atomline[7];
+		receivename = app.app.replaceDollarZero(atomline[7]);
 
 		setval(0, 0);
 

--- a/src/cx/mccormick/pddroidparty/Widget.java
+++ b/src/cx/mccormick/pddroidparty/Widget.java
@@ -98,7 +98,7 @@ public class Widget {
 
 	public void initCommonArgs(PdDroidPatchView app, String[] atomline, int index, boolean isCanvas) {
 		sendname = app.app.replaceDollarZero(atomline[index++]);
-		receivename = atomline[index++];
+		receivename = app.app.replaceDollarZero(atomline[index++]);
 		label = setLabel(atomline[index++]);
 		labelpos[0] = Float.parseFloat(atomline[index++]) ;
 		labelpos[1] = Float.parseFloat(atomline[index++]) ;


### PR DESCRIPTION
Long standing issue!
Receivenames have been forgotten when dollarzero replacement has been implemented... in 2012 ;-)
Only sendnames had been addressed.